### PR TITLE
Extend tested range in conf-python-3-7

### DIFF
--- a/patches/conf-python-3-7.1/configure.sh
+++ b/patches/conf-python-3-7.1/configure.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 N"
+  exit 1
+fi
+
+minor_bound=$1
+
+for minor in $(seq $minor_bound -1 7); do
+    version="3.$minor"
+    python_exe="python$version"
+    if "$python_exe" test.py; then
+        echo "python3: \"$python_exe\"" >> conf-python-3-7.config
+        exit 0
+    fi
+done
+exit 1

--- a/patches/conf-python-3-7.1/test.py
+++ b/patches/conf-python-3-7.1/test.py
@@ -1,0 +1,2 @@
+import sys
+assert(sys.hexversion >= 0x03070000)


### PR DESCRIPTION
Extend tested range to include Python 3.12 and 3.13.

Missing 3.12 support cause a failure in https://github.com/ocaml/opam-repository/pull/25990
Since Python 3.13 seems to be nearing a release, I've added that too to avoid having to come back and patch too soon again.

The needs a corresponding sha512 update to the above opam-repo PR.