### PR TITLE
Prepare to release LLVM 19

### DIFF
--- a/patches/llvm/AddOCaml.cmake.patch.19
+++ b/patches/llvm/AddOCaml.cmake.patch.19
@@ -1,0 +1,109 @@
+diff --git a/llvm/cmake/modules/AddOCaml.cmake b/llvm/cmake/modules/AddOCaml.cmake
+index 2d9116b08a52..35ef26c149bc 100644
+--- a/llvm/cmake/modules/AddOCaml.cmake
++++ b/llvm/cmake/modules/AddOCaml.cmake
+@@ -38,12 +38,23 @@ function(add_ocaml_library name)
+   set(ocaml_inputs)
+ 
+   set(ocaml_outputs "${bin}/${name}.cma")
++
++  # OCaml custom runtime is necessary when compiling to bytecode and linking
++  # to the LLVM static libs. Otherwise, errors of the form
++  # `CommandLine Error: Option ... registered more than once!` will occur.
++  if ( LLVM_LINK_LLVM_DYLIB OR BUILD_SHARED_LIBS )
++    set(ocaml_custom FALSE)
++  else()
++    set(ocaml_custom TRUE)
++  endif()
++
+   if( ARG_C )
++    # ocamlmklib outputs .a and .so
+     list(APPEND ocaml_outputs
+-         "${bin}/lib${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+-    if ( BUILD_SHARED_LIBS )
++         "${bin}/lib${name}.a")
++    if( NOT ocaml_custom )
+       list(APPEND ocaml_outputs
+-           "${bin}/dll${name}${CMAKE_SHARED_LIBRARY_SUFFIX}")
++           "${bin}/dll${name}.so")
+     endif()
+   endif()
+   if( HAVE_OCAMLOPT )
+@@ -52,39 +63,48 @@ function(add_ocaml_library name)
+          "${bin}/${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+   endif()
+ 
+-  set(ocaml_flags "-lstdc++" "-ldopt" "-L${LLVM_LIBRARY_DIR}"
+-                  "-ccopt" "-L\\$CAMLORIGIN/../.."
+-                  "-ccopt" "-Wl,-rpath,\\$CAMLORIGIN/../.."
+-                  ${ocaml_pkgs})
++  if ( LLVM_OCAML_OUT_OF_TREE )
++    set(ocaml_flags "-L${LLVM_OCAML_EXTERNAL_LLVM_LIBDIR}" ${ocaml_pkgs})
++  else()
++    set(ocaml_flags "-ldopt" "-L${LLVM_LIBRARY_DIR}" ${ocaml_pkgs})
++  endif()
++
++  if (LLVM_OCAML_USE_HOMEBREW)
++    list(APPEND ocaml_flags "-L$ENV{HOMEBREW_PREFIX}/lib")
++  endif()
+ 
+   foreach( ocaml_dep ${ARG_OCAMLDEP} )
+     get_target_property(dep_ocaml_flags "ocaml_${ocaml_dep}" OCAML_FLAGS)
+     list(APPEND ocaml_flags ${dep_ocaml_flags})
+   endforeach()
+ 
+-  if( NOT BUILD_SHARED_LIBS )
++  if( ocaml_custom )
+     list(APPEND ocaml_flags "-custom")
+   endif()
+ 
+   if(LLVM_LINK_LLVM_DYLIB)
+-    list(APPEND ocaml_flags "-lLLVM")
++    list(APPEND ocaml_flags "-lLLVM-${LLVM_VERSION_MAJOR}")
+   else()
++
+     explicit_map_components_to_libraries(llvm_libs ${ARG_LLVM})
+     foreach( llvm_lib ${llvm_libs} )
++      # Don't use -cclib here, so ocamlmklib won't include these in the
++      # dylib files
+       list(APPEND ocaml_flags "-l${llvm_lib}" )
+     endforeach()
+-
+-    get_property(system_libs TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS)
+-    foreach(system_lib ${system_libs})
+-      if (system_lib MATCHES "^-")
+-        # If it's an option, pass it without changes.
+-        list(APPEND ocaml_flags "${system_lib}" )
+-      else()
+-        # Otherwise assume it's a library name we need to link with.
+-        list(APPEND ocaml_flags "-l${system_lib}" )
+-      endif()
+-    endforeach()
+   endif()
++  get_property(system_libs TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS)
++  foreach(system_lib ${system_libs})
++    if (system_lib MATCHES "^-")
++      # If it's an option, pass it without changes.
++      list(APPEND ocaml_flags "${system_lib}" )
++    else()
++      # Otherwise assume it's a library name we need to link with.
++      list(APPEND ocaml_flags "-l${system_lib}" )
++    endif()
++  endforeach()
++  # Pass -lstdc++ at the end because link order matters
++  list(APPEND ocaml_flags "-lstdc++")
+ 
+   string(REPLACE ";" " " ARG_CFLAGS "${ARG_CFLAGS}")
+   set(c_flags "${ARG_CFLAGS} ${LLVM_DEFINITIONS}")
+@@ -201,9 +221,9 @@ function(add_ocaml_library name)
+     if( NOT (ext STREQUAL ".cmo" OR
+              ext STREQUAL ".ml" OR
+              ext STREQUAL CMAKE_C_OUTPUT_EXTENSION OR
+-             ext STREQUAL CMAKE_SHARED_LIBRARY_SUFFIX) )
++             ext STREQUAL ".so") )
+       list(APPEND install_files "${ocaml_output}")
+-    elseif( ext STREQUAL CMAKE_SHARED_LIBRARY_SUFFIX)
++    elseif( ext STREQUAL ".so")
+       list(APPEND install_shlibs "${ocaml_output}")
+     endif()
+   endforeach()


### PR DESCRIPTION
For this release, I made some small changes to the patch file. For the statically linked LLVM, native and "byte complete" executables are supported. However, I am not supporting "ordinary" bytecode executables with statically linked LLVM, as this causes duplicate LLVM libraries to be linked, causing errors.