### PR TITLE
async_ssl: restore -Wno-implicit-function-declaration in >= 0.16.1

### DIFF
--- a/patches/async_ssl/no-warnings-0161-2.patch
+++ b/patches/async_ssl/no-warnings-0161-2.patch
@@ -1,0 +1,15 @@
+--- a/src/dune
++++ b/src/dune
+@@ -15,7 +15,9 @@
+   ffi__library_must_be_initialized rfc3526 ssl initialize std config tls)
+  (c_names ffi_generated_stubs) (flags :standard -w -9-27-32-34)
+  (c_flags (:standard \ -Werror -pedantic -Wall -Wunused) -w
+-  (:include ../bindings/openssl-ccopt.sexp))
++  (:include ../bindings/openssl-ccopt.sexp)
++  -Wno-implicit-function-declaration
++  -Wno-incompatible-pointer-types)
+  (c_library_flags :standard (:include ../bindings/openssl-cclib.sexp))
+  (libraries async core async_ssl_bindings ctypes.stubs ctypes)
+- (preprocess (pps ppx_jane)))
+\ No newline at end of file
++ (preprocess (pps ppx_jane)))

--- a/patches/async_ssl/no-warnings-017-2.patch
+++ b/patches/async_ssl/no-warnings-017-2.patch
@@ -1,0 +1,13 @@
+--- a/src/dune
++++ b/src/dune
+@@ -26,7 +26,9 @@
+   (flags
+    (:standard \ -Werror -pedantic -Wall -Wunused)
+    -w
+-   (:include ../bindings/openssl-ccopt.sexp)))
++   (:include ../bindings/openssl-ccopt.sexp)
++   -Wno-implicit-function-declaration
++   -Wno-incompatible-pointer-types))
+  (name async_ssl)
+  (public_name async_ssl)
+  (modules import version opt verify_mode ffi_generated_types ffi_generated


### PR DESCRIPTION
Short story
---

Adds two patches that restore the `-Wno-implicit-function-declaration` C flag suppression that was present in `no-incompatible-pointer-types-0160.patch` but dropped when the patch was rewritten for v0.16.1-1 and v0.17.0-1.

Long story
---
`async_ssl`'s `ffi_generated_stubs.c` references the deprecated OpenSSL `ENGINE_load_builtin_engines` and `ENGINE_register_all_complete` functions without including `<openssl/engine.h>`. On distros where OpenSSL is built with the `ENGINE` API stripped (or where the headers no longer expose those symbols at default warning levels), GCC reports them as implicit declarations, which is a hard error under modern GCC defaults (GCC 14+).

  | Revision   | Suppresses `-Wimplicit-function-declaration`? |
  |------------|------------------------------------------------|
  | v0.16.0-1  | Yes                                            |
  | v0.16.1-1  | No (regression)                                |
  | v0.17.0-1  | No (regression continued)                      |

Real world specimen:

opam-ci hits this on `centos-10-ocaml-5.4` (and others): https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/a9188c69fee7c73594bf9c9017588e99452b8f44/variant/distributions,centos-10-ocaml-5.4,awso-async.0.9.0